### PR TITLE
Fix for getting a single project

### DIFF
--- a/lib/Sifter/Projects.php
+++ b/lib/Sifter/Projects.php
@@ -24,7 +24,8 @@ class Projects
     public function get($id)
     {
         $endpoint = '/api/projects/' . $id;
-        return new Project(Request::make($endpoint));
+        $project = Request::make($endpoint);
+        return new Project($project['project']);
     }
 
 }


### PR DESCRIPTION
This PR fixes the `$sifter->projects()->get()` call, which was not working.
